### PR TITLE
Fix source URL in rockspec

### DIFF
--- a/mediator_lua-1.1.1-0.rockspec
+++ b/mediator_lua-1.1.1-0.rockspec
@@ -1,7 +1,7 @@
 package = "mediator_lua"
 version = "1.1.1-0"
 source = {
-  url = "https://github.com/Olivine-Labs/mediator_lua/archive/v1.1.1.tar.gz",
+  url = "https://github.com/Olivine-Labs/mediator_lua/archive/v1.1.0.tar.gz",
   dir = "mediator_lua-1.1.1"
 }
 description = {

--- a/mediator_lua-1.1.1-0.rockspec
+++ b/mediator_lua-1.1.1-0.rockspec
@@ -1,8 +1,8 @@
 package = "mediator_lua"
-version = "1.1-3"
+version = "1.1.1-0"
 source = {
-  url = "https://github.com/Olivine-Labs/mediator_lua/archive/v1.1.tar.gz",
-  dir = "mediator_lua-1.1"
+  url = "https://github.com/Olivine-Labs/mediator_lua/archive/v1.1.1.tar.gz",
+  dir = "mediator_lua-1.1.1"
 }
 description = {
   summary = "Event handling through channels",


### PR DESCRIPTION
v1.1.0 not v1.1.1 (this patch attempts to fixes the following error):

```
Error: Failed installing dependency: http://rocks.moonscript.org/mediator_lua-1.1.1-0.rockspec - Error fetching file: Failed downloading https://github.com/Olivine-Labs/mediator_lua/archive/v1.1.1.tar.gz
```